### PR TITLE
[AC-5696] Allow Judging Round to be selected

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DEV_IMPACT_API_SITE_URL=http://localhost

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,8 @@ test: setup
 coverage: setup
 	@echo mocha not enabled yet
 
-run-server: setup
+.env: .env.example
+	@cp .env.example .env
+
+run-server: .env setup
 	@yarn start

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   },
   "dependencies": {
     "babel-preset-react-app": "^3.1.1",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "react": ">=0.14.0 <= 16",
+    "react-dom": ">=0.14.0 <= 16",
+    "semantic-ui-css": "^2.3.1",
+    "semantic-ui-react": "^0.81.1"
   },
   "jest": {
     "moduleNameMapper": {

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import Header from './header';
+
+import JudgingRoundSelector from './judging_round_selector';
+
+
+class App extends React.Component {
+    render() {
+	return (<div>
+		<Header value='Application Allocator Setup'/>
+		<JudgingRoundSelector />
+		</div>);
+    }
+}
+
+export default App;

--- a/src/app.js
+++ b/src/app.js
@@ -1,14 +1,27 @@
 import React from 'react'
 import Header from './header';
 
+import JudgingRoundDisplay from './judging_round_display';
 import JudgingRoundSelector from './judging_round_selector';
 
 
 class App extends React.Component {
+    constructor(props) {
+	super(props);
+	this.state = {
+            judging_round: null,
+	};
+    }
+
+    select_judging_round = (_, data) => {
+	this.setState({judging_round: data.value})
+    }
+
     render() {
 	return (<div>
 		<Header value='Application Allocator Setup'/>
-		<JudgingRoundSelector />
+		<JudgingRoundSelector on_select={this.select_judging_round}/>
+		<JudgingRoundDisplay judging_round={this.state.judging_round}/>
 		</div>);
     }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -6,12 +6,7 @@ import JudgingRoundSelector from './judging_round_selector';
 
 
 class App extends React.Component {
-    constructor(props) {
-	super(props);
-	this.state = {
-            judging_round: null,
-	};
-    }
+    state = { judging_round: null }
 
     select_judging_round = (_, data) => {
 	this.setState({judging_round: data.value})

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'semantic-ui-css/semantic.min.css'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import Header from './header';
@@ -6,8 +7,8 @@ import JudgingRoundSelector from './judging_round_selector';
 
 ReactDOM.render(
 	<div>
-	<Header value='Hello, World!'/>
-	<JudgingRoundSelector/>
+	  <Header value='Application Allocator Setup'/>
+	  <JudgingRoundSelector/>
 	</div>,
-    document.getElementById('root')
+        document.getElementById('root')
 )

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import Header from './header';
-import ApiCall from './api_call';
+import JudgingRoundSelector from './judging_round_selector';
 
 
 ReactDOM.render(
 	<div>
 	<Header value='Hello, World!'/>
-	<ApiCall/>
+	<JudgingRoundSelector/>
 	</div>,
     document.getElementById('root')
 )

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,10 @@
 import 'semantic-ui-css/semantic.min.css'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Header from './header';
-import JudgingRoundSelector from './judging_round_selector';
+import App from './app';
 
 
 ReactDOM.render(
-	<div>
-	  <Header value='Application Allocator Setup'/>
-	  <JudgingRoundSelector/>
-	</div>,
-        document.getElementById('root')
+	<App />,
+    document.getElementById('root')
 )

--- a/src/judging_round_display.js
+++ b/src/judging_round_display.js
@@ -34,7 +34,7 @@ class JudgingRoundDisplay extends React.Component {
 		    <li>Program Id: {this.state.data.program_id}</li>
 		    </ul>)
 	} else {
-	    return (<div/>)
+	    return (<div>No Judging Round Selected</div>)
 	}
     }
 }

--- a/src/judging_round_display.js
+++ b/src/judging_round_display.js
@@ -1,0 +1,42 @@
+import React from 'react'
+
+
+class JudgingRoundDisplay extends React.Component {
+    state = {
+        data: {},
+    }
+
+    componentDidUpdate(prevProps) {
+	const judging_round_id = this.props.judging_round
+	if (judging_round_id &&
+	      prevProps.judging_round !== this.props.judging_round) {
+            fetch("http://localhost:8000/api/v1/judging_round/" +
+		  judging_round_id + "/",
+		  {credentials: "include", mode: "cors"})
+		.then(res => res.json()).then(data => {
+		    this.setState({ data: data })
+		})
+	}
+    }
+    
+    render() {
+	if (this.props.judging_round) {
+	    return (<ul>
+		    <li>Full Name: {this.state.data.full_name}</li>
+		    <li>Id: {this.state.data.id}</li>
+		    <li>Is Active: {
+			this.state.data.is_active ? "True" : "False"}
+		    </li>
+		    <li>Round Type: {this.state.data.round_type}</li>
+		    <li>Cycle Based Round: {
+			this.state.data.cycle_based_round ? "True" : "False"}
+		    </li>
+		    <li>Program Id: {this.state.data.program_id}</li>
+		    </ul>)
+	} else {
+	    return (<div/>)
+	}
+    }
+}
+
+export default JudgingRoundDisplay;

--- a/src/judging_round_display.js
+++ b/src/judging_round_display.js
@@ -1,4 +1,12 @@
 import React from 'react'
+import judgingRoundUrl from './utils'
+
+
+const fetchJudgingRoundData = (id) => {
+    const full_url = judgingRoundUrl + id + "/"
+    return fetch(full_url, {credentials: "include", mode: "cors"})
+	.then(res => res.json())
+}
 
 
 class JudgingRoundDisplay extends React.Component {
@@ -10,10 +18,8 @@ class JudgingRoundDisplay extends React.Component {
 	const judging_round_id = this.props.judging_round
 	if (judging_round_id &&
 	      prevProps.judging_round !== this.props.judging_round) {
-            fetch("http://localhost:8000/api/v1/judging_round/" +
-		  judging_round_id + "/",
-		  {credentials: "include", mode: "cors"})
-		.then(res => res.json()).then(data => {
+	    fetchJudgingRoundData(judging_round_id)
+		.then(data => {
 		    this.setState({ data: data })
 		})
 	}

--- a/src/judging_round_display.test.js
+++ b/src/judging_round_display.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {shallow} from 'enzyme';
+import JudgingRoundDisplay from './judging_round_display';
+
+
+describe('judging round display', () => {
+    it('says when no judging round is selected', () => {
+	const display = shallow(<JudgingRoundDisplay judging_round={null}/>);
+	expect(display.text()).toContain('No Judging Round Selected');
+    });
+});

--- a/src/judging_round_selector.js
+++ b/src/judging_round_selector.js
@@ -1,5 +1,13 @@
 import React from 'react'
 import { Form, Select } from 'semantic-ui-react'
+import judgingRoundUrl from './utils'
+
+
+const fetchJudgingRoundList = () => {
+    const full_url = judgingRoundUrl
+    return fetch(full_url, {credentials: "include", mode: "cors"})
+	.then(res => res.json())
+}
 
 
 class JudgingRoundSelector extends React.Component {
@@ -13,9 +21,7 @@ class JudgingRoundSelector extends React.Component {
     }
 
     componentDidMount() {
-        fetch("http://localhost:8000/api/v1/judging_round/?round_type=Online",
-              {credentials: "include", mode: "cors"})
-            .then(res => res.json())
+	fetchJudgingRoundList()
             .then(
                 (result) => {
                     this.setState({

--- a/src/judging_round_selector.js
+++ b/src/judging_round_selector.js
@@ -1,54 +1,50 @@
 import React from 'react'
+import { Form, Select } from 'semantic-ui-react'
 
 class JudgingRoundSelector extends React.Component {
     constructor(props) {
-	super(props);
-	this.state = {
-	    error: null,
-	    isLoaded: false,
-	    user: []
-	};
+        super(props);
+        this.state = {
+            error: null,
+            isLoaded: false,
+            user: []
+        };
     }
 
     componentDidMount() {
-	fetch("http://localhost:8000/api/v1/judging_round/?is_active=True",
-	      {credentials: "include", mode: "cors"})
-	    .then(res => res.json())
-	    .then(
-		(result) => {
-		    this.setState({
-			isLoaded: true,
-			results: result['results'],
-		    });
-		},
-		// Note: it's important to handle errors here
-		// instead of a catch() block so that we don't swallow
-		// exceptions from actual bugs in components.
-		(error) => {
-		    this.setState({
-			isLoaded: true,
-			error
-		    });
-		}
-	    )
-	// this.setState({isLoaded: true,
-	// items: [{name: 'bar', price: 1.00}]})
+        fetch("http://localhost:8000/api/v1/judging_round/?round_type=Online",
+              {credentials: "include", mode: "cors"})
+            .then(res => res.json())
+            .then(
+                (result) => {
+                    this.setState({
+                        isLoaded: true,
+                        results: result['results'],
+                    });
+                },
+                (error) => {
+                    this.setState({
+                        isLoaded: true,
+                        error
+                    });
+                }
+            )
     }
 
     render() {
-	const { error, isLoaded, results } = this.state;
-	if (error) {
-	    return <div>Error: {error.message}</div>;
-	} else if (!isLoaded) {
-	    return <div>Loading...</div>;
-	} else {
-	    return (<ul>
-		    {results.map(result => (
-			<li key={result.id}>
-			    {result.full_name}
-			</li>))}
-		    </ul>);
-	}
+        const { error, isLoaded, results } = this.state;
+        if (error) {
+            return <div>Error: {error.message}</div>;
+        } else if (!isLoaded) {
+            return <div>Loading...</div>;
+        } else {
+            const options = results.map(result => ({key: result.id,
+                                              text: result.full_name,
+                                              value: result.id}))
+            return (<Form.Field control={Select}
+                                label="Judging Round: "
+                                options={options} />);
+        }
     }
 }
 

--- a/src/judging_round_selector.js
+++ b/src/judging_round_selector.js
@@ -42,9 +42,10 @@ class JudgingRoundSelector extends React.Component {
             const options = results.map(result => ({key: result.id,
                                               text: result.full_name,
                                               value: result.id}))
-            return (<Form.Field control={Select}
-                                label="Judging Round: "
-                                options={options} />);
+            return (<Form.Select
+                    label={"Judging Round: "}
+		    onChange={this.props.on_select}
+                    options={options} />);
         }
     }
 }

--- a/src/judging_round_selector.js
+++ b/src/judging_round_selector.js
@@ -1,0 +1,55 @@
+import React from 'react'
+
+class JudgingRoundSelector extends React.Component {
+    constructor(props) {
+	super(props);
+	this.state = {
+	    error: null,
+	    isLoaded: false,
+	    user: []
+	};
+    }
+
+    componentDidMount() {
+	fetch("http://localhost:8000/api/v1/judging_round/?is_active=True",
+	      {credentials: "include", mode: "cors"})
+	    .then(res => res.json())
+	    .then(
+		(result) => {
+		    this.setState({
+			isLoaded: true,
+			results: result['results'],
+		    });
+		},
+		// Note: it's important to handle errors here
+		// instead of a catch() block so that we don't swallow
+		// exceptions from actual bugs in components.
+		(error) => {
+		    this.setState({
+			isLoaded: true,
+			error
+		    });
+		}
+	    )
+	// this.setState({isLoaded: true,
+	// items: [{name: 'bar', price: 1.00}]})
+    }
+
+    render() {
+	const { error, isLoaded, results } = this.state;
+	if (error) {
+	    return <div>Error: {error.message}</div>;
+	} else if (!isLoaded) {
+	    return <div>Loading...</div>;
+	} else {
+	    return (<ul>
+		    {results.map(result => (
+			<li key={result.id}>
+			    {result.full_name}
+			</li>))}
+		    </ul>);
+	}
+    }
+}
+
+export default JudgingRoundSelector;

--- a/src/judging_round_selector.js
+++ b/src/judging_round_selector.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Form, Select } from 'semantic-ui-react'
 
+
 class JudgingRoundSelector extends React.Component {
     constructor(props) {
         super(props);

--- a/src/judging_round_selector.test.js
+++ b/src/judging_round_selector.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {shallow} from 'enzyme';
+import JudgingRoundSelector from './judging_round_selector';
+
+
+describe('judging round selector', () => {
+    // // This requires mocks.  See AC-5727
+    // it('has judging round label', () => {
+    // 	const selector = shallow(<JudgingRoundSelector judging_round={null}/>);
+    // 	expect(selector.text()).toContain('Judging Round');
+    // });
+    it('does not work yet', () => {
+	expect(true);
+    });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,4 @@
+export const judgingRoundUrl = (process.env.DEV_IMPACT_API_SITE_URL +
+				"/api/v1/judging_round/")
+
+export default judgingRoundUrl

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.0.0-beta.49":
+  version "7.0.0-beta.50"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.50.tgz#82e354aa9c97e399649b74869e059bcd69f61dca"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
 "@types/node@*":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.0.tgz#078516315a84d56216b5d4fed8f75d59d3b16cac"
@@ -1255,6 +1262,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1418,7 +1429,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -3152,6 +3163,10 @@ jest@^23.1.0:
     import-local "^1.0.0"
     jest-cli "^23.1.0"
 
+jquery@x.*:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+
 js-base64@^2.1.9:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
@@ -3263,6 +3278,10 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+keyboard-key@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/keyboard-key/-/keyboard-key-1.0.1.tgz#a946294fe59ad5431c63a3ea269f023e51fac6aa"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4398,7 +4417,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -4518,7 +4537,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.3.2:
+"react-dom@>=0.14.0 <= 16":
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
   dependencies:
@@ -4549,7 +4568,7 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.2:
     prop-types "^15.6.0"
     react-is "^16.4.0"
 
-react@^16.3.2:
+"react@>=0.14.0 <= 16":
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:
@@ -4618,7 +4637,7 @@ regenerate@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -4822,6 +4841,23 @@ sane@^2.0.0:
 sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+semantic-ui-css@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/semantic-ui-css/-/semantic-ui-css-2.3.1.tgz#a5485c640c98cce29d8ddde3eff3434566a068e0"
+  dependencies:
+    jquery x.*
+
+semantic-ui-react@^0.81.1:
+  version "0.81.1"
+  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-0.81.1.tgz#9bf8e1949aac8584173f0acb11c6ce05008bcbfc"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.49"
+    classnames "^2.2.5"
+    fbjs "^0.8.16"
+    keyboard-key "^1.0.1"
+    lodash "^4.17.10"
+    prop-types "^15.6.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
To test:
- Startup accelerate and impact-api on the development branch.
- Login to accelerate.
- Run `make run-server` in application-allocator.
- Page should show a dropdown with a set of judging rounds that you can select from.
- When you select a judging round some details about that judging round should be shown.

Note: Tests are kind of incomplete since they require mocks for the API calls and I haven't taken the time to figure that out yet.  See AC-5727.
