### PR TITLE
AC-5626: Support for Analysis Display

### DIFF
--- a/src/AnalyzeJudgingRoundDisplay.js
+++ b/src/AnalyzeJudgingRoundDisplay.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { analyzeJudgingRoundUrl } from './utils';
+import CriterionDisplay from './CriterionDisplay';
+
+
+class AnalyzeJudgingRoundDisplay extends React.Component {
+    state = {
+        data: {"init": true},
+    }
+
+    fetchAnalyzeJudgingRoundData(id) {
+	const full_url = analyzeJudgingRoundUrl + id + "/"
+	return fetch(full_url, {credentials: "include", mode: "cors"})
+	    .then(res => res.json())
+	    .then(data => {
+		this.setState({ data })
+	    })
+    }
+
+    componentDidUpdate(prevProps) {
+	const judging_round_id = this.props.judging_round
+	if (judging_round_id &&
+	      prevProps.judging_round !== this.props.judging_round) {
+	    this.fetchAnalyzeJudgingRoundData(judging_round_id)
+	}
+    }
+
+    render() {
+	if (this.props.judging_round) {
+	    const data = this.state.data
+	    if (data.results && data.results.length > 0) {
+		var criteria = data.results.map(function(analysis){
+		    return <li><CriterionDisplay analysis={analysis}/></li>
+		})
+		return <ul>{ criteria }</ul>
+	    }
+	}
+	return (<div>No Judging Round Selected</div>)
+    }
+}
+
+export default AnalyzeJudgingRoundDisplay;

--- a/src/AnalyzeJudgingRoundDisplay.js
+++ b/src/AnalyzeJudgingRoundDisplay.js
@@ -35,7 +35,7 @@ class AnalyzeJudgingRoundDisplay extends React.Component {
 		return <ul>{ criteria }</ul>
 	    }
 	}
-	return (<div>No Judging Round Selected</div>)
+	return (<div>No analysis data available</div>)
     }
 }
 

--- a/src/CriterionDisplay.js
+++ b/src/CriterionDisplay.js
@@ -10,8 +10,8 @@ class CriterionDisplay extends React.Component {
                 { analysis.criterion_name } { analysis.option }:
             Status: { analysis.completed_required_reads } of {analysis.total_required_reads},
             Need: { analysis.remaining_needed_reads },
-            Available: { analysis.remaining_commitments },
-            Buffer: { analysis.remaining_commitments - analysis.remaining_needed_reads }
+            Available: { analysis.remaining_capacity },
+            Buffer: { analysis.remaining_capacity - analysis.remaining_needed_reads }
             </div>)
     }
 }

--- a/src/CriterionDisplay.js
+++ b/src/CriterionDisplay.js
@@ -4,8 +4,15 @@ import { analyzeJudgingRoundUrl } from './utils'
 
 class CriterionDisplay extends React.Component {
     render() {
-	const analysis = this.props.analysis
-	return <div>{ analysis.criterion_name }: { analysis.option }</div>
+        const analysis = this.props.analysis
+        return (
+            <div>
+                { analysis.criterion_name } { analysis.option }:
+            Status: { analysis.completed_required_reads } of {analysis.total_required_reads},
+            Need: { analysis.remaining_needed_reads },
+            Available: { analysis.remaining_commitments },
+            Buffer: { analysis.remaining_commitments - analysis.remaining_needed_reads }
+            </div>)
     }
 }
 

--- a/src/CriterionDisplay.js
+++ b/src/CriterionDisplay.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { analyzeJudgingRoundUrl } from './utils'
+
+
+class CriterionDisplay extends React.Component {
+    render() {
+	const analysis = this.props.analysis
+	return <div>{ analysis.criterion_name }: { analysis.option }</div>
+    }
+}
+
+export default CriterionDisplay

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Header from './header';
 
+import AnalyzeJudgingRoundDisplay from './AnalyzeJudgingRoundDisplay';
 import JudgingRoundDisplay from './judging_round_display';
 import JudgingRoundSelector from './judging_round_selector';
 
@@ -17,8 +18,11 @@ class App extends React.Component {
 		<Header value='Application Allocator Setup'/>
 		<JudgingRoundSelector on_select={this.select_judging_round}/>
 		<JudgingRoundDisplay judging_round={this.state.judging_round}/>
+		<AnalyzeJudgingRoundDisplay judging_round={this.state.judging_round}/>
 		</div>);
     }
 }
+
+
 
 export default App;

--- a/src/judging_round_display.js
+++ b/src/judging_round_display.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import judgingRoundUrl from './utils'
+import { analyzeJudgingRoundUrl, judgingRoundUrl } from './utils'
 
 
 class JudgingRoundDisplay extends React.Component {

--- a/src/judging_round_display.js
+++ b/src/judging_round_display.js
@@ -30,6 +30,8 @@ class JudgingRoundDisplay extends React.Component {
 	    return (<ul>
 		    <li>Props Judging Round: {this.props.judging_round}</li>
 		    <li>Full Name: {data.full_name}</li>
+		    <li>Start Date: {data.start_date_time}</li>
+		    <li>End Date: {data.end_date_time}</li>
 		    <li>Id: {data.id}</li>
 		    <li>Is Active: {data.is_active ? "True" : "False"}
 		    </li>

--- a/src/judging_round_selector.js
+++ b/src/judging_round_selector.js
@@ -16,7 +16,7 @@ class JudgingRoundSelector extends React.Component {
     }
 
     fetchJudgingRoundList() {
-	fetch(judgingRoundUrl, {credentials: "include", mode: "cors"})
+	fetch(judgingRoundUrl + "?round_type=Online", {credentials: "include", mode: "cors"})
 	    .then(res => res.json())
 	    .then(
                 (result) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
-export const judgingRoundUrl = (process.env.DEV_IMPACT_API_SITE_URL +
-				"/api/v1/judging_round/")
+export const analyzeJudgingRoundUrl = process.env.DEV_IMPACT_API_SITE_URL + "/api/v1/analyze_judging_round/"
+
+export const judgingRoundUrl = process.env.DEV_IMPACT_API_SITE_URL + "/api/v1/judging_round/"
 
 export default judgingRoundUrl


### PR DESCRIPTION
To test:
Once everything is running, select "2017-04 BOS CH IL Round 1" from the drop down and wait about 10 seconds for the results to show up.  Should see the data requested in the ticket as well as the data needed to drive Hugh's UI.  Note: This ticket does not attempt to implement Hugh's UI.  That is handled in AC-5803.  It should look something like the attached image.

![screen shot 2018-07-11 at 4 04 06 pm](https://user-images.githubusercontent.com/9534003/42596557-16cb3802-8524-11e8-92db-0fe96163d984.png)
